### PR TITLE
Fix jsmediatags dist issue (#47)

### DIFF
--- a/copy_dependencies.sh
+++ b/copy_dependencies.sh
@@ -17,6 +17,6 @@ cp bower_components/podStationNGReuse/dist/podStationNGReuse.min.js $LIB_PATH/po
 cp bower_components/font-awesome/css/font-awesome.min.css $LIB_PATH/font-awesome.min.css
 cp bower_components/font-awesome/fonts/* $FONTS_PATH
 
-cp bower_components/jsmediatags/dist/jsmediatags.js $LIB_PATH/jsmediatags.js
+cp bower_components/jsmediatags/dist/jsmediatags.min.js $LIB_PATH/jsmediatags.min.js
 
 cp bower_components/ngInfiniteScroll/build/ng-infinite-scroll.min.js $LIB_PATH/ng-infinite-scroll.min.js

--- a/extension/background/background.html
+++ b/extension/background/background.html
@@ -2,7 +2,7 @@
 <html>
 	<script type="text/javascript" src="/lib/jquery.min.js"></script>
 	<script type="text/javascript" src="/lib/angular.js"></script>
-	<script type="text/javascript" src="/lib/jsmediatags.js"></script>
+	<script type="text/javascript" src="/lib/jsmediatags.min.js"></script>
 	<script type="text/javascript" src="/lib/podStationNGReuse.min.js"></script>
 	
 	<!-- Internal reusables (pages and background)-->

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function(config) {
       'extension/lib/jquery.min.js',
       'extension/lib/angular.js',
       'extension/lib/podStationNGReuse.min.js',
-      'extension/lib/jsmediatags.js',
+      'extension/lib/jsmediatags.min.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'extension/reuse/**/*.js',
       'extension/background/entities/backgroundApp.js',


### PR DESCRIPTION
This commit fixes #47

https://github.com/podStation/podStation/issues/47

Our bower dependency for jsmediatags is "^3.9.0", which means
it picks newer versions as well (I don't know the specifics
by heart, but at least now it is selecting 3.9.3).

From 3.9.0 to 3.9.3 there was a non-backwards compatible change
in distribution (now the minified version is distributed instead),
with a change on the file name.

This was the root cause for the build failure.
I could pin the dependency to 3.9.3 exactly (matter of fact, I
only tought about it while writing this commit), but I see that
the risk of happending again is rather low, so I decided not to
do that.

Reference:
https://github.com/aadsm/jsmediatags/commit/aab8bb0951f3b7c95aeb4a8e37b3f7e59b2c6653#diff-0a08a7565aba4405282251491979bb6b