### PR TITLE
Fix text overflow issues

### DIFF
--- a/extension/podstation.css
+++ b/extension/podstation.css
@@ -190,6 +190,7 @@ h1 {
 
 .itemDescription {
 	padding-top: 10px;
+	word-break: break-word;
 }
 
 .itemDescription a, #aboutContent a {

--- a/extension/ui/ng/partials/episodePlayer.html
+++ b/extension/ui/ng/partials/episodePlayer.html
@@ -22,11 +22,11 @@
 
 .audioPlayer td a {
 	color: white;
-	white-space: normal;
 }
 
 .audioPlayer td:last-child{
 	width:100%;
+	white-space: normal;
 }
 
 #progressOut {

--- a/extension/ui/ng/partials/episodePlayer.html
+++ b/extension/ui/ng/partials/episodePlayer.html
@@ -22,6 +22,7 @@
 
 .audioPlayer td a {
 	color: white;
+	white-space: normal;
 }
 
 .audioPlayer td:last-child{


### PR DESCRIPTION
This commit resolves two issues:
1. Mentioned in #174 
2. Fixes issue when text is very long without any space in the description

![image](https://user-images.githubusercontent.com/64042104/99910671-4cbdc380-2d15-11eb-92ea-0d182dfd4a5c.png)
