### PR TITLE
Fix #190 - Episode title layout change

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -182,7 +182,7 @@
 	},
 	// episodes
 	"all_eps_from": {
-		"message": "All episodes from <i>$podcast$</i>",
+		"message": "All episodes from<br><i>$podcast$</i>",
 		"placeholders": {
 			"podcast": {
 				"content": "$1"

--- a/extension/_locales/nl/messages.json
+++ b/extension/_locales/nl/messages.json
@@ -182,7 +182,7 @@
 	},
 	// episodes
 	"all_eps_from": {
-		"message": "Alle afleveringen van <i>$podcast$</i>",
+		"message": "Alle afleveringen van<br><i>$podcast$</i>",
 		"placeholders": {
 			"podcast": {
 				"content": "$1"

--- a/extension/_locales/pt_BR/messages.json
+++ b/extension/_locales/pt_BR/messages.json
@@ -181,7 +181,7 @@
 	},
 	// episodes
 	"all_eps_from": {
-		"message": "Todos os episódios de <i>$podcast$</i>",
+		"message": "Todos os episódios de<br><i>$podcast$</i>",
 		"placeholders": {
 			"podcast": {
 				"content": "$1"

--- a/extension/podstation.css
+++ b/extension/podstation.css
@@ -139,6 +139,19 @@ h1 {
 	background-color: Gainsboro;*/
 }
 
+div.sectionTitleImage {
+	float: left;
+	padding-top: 8px;
+	padding-left: 0px;
+	padding-right: 12px;
+	padding-bottom: 0px;
+}
+
+div.sectionTitleImage img {
+	max-width: 64px;
+	height: 64px;
+}
+
 .sectionTitle {
 	font-size: 30px;
 }

--- a/extension/podstation.css
+++ b/extension/podstation.css
@@ -24,6 +24,10 @@ a:visited {
 	color: black;
 }
 
+#contentBoxIn {
+	padding-top: 10px;
+}
+
 .icon {
 	transition: 0.5s;
 }

--- a/extension/podstation.css
+++ b/extension/podstation.css
@@ -25,7 +25,7 @@ a:visited {
 }
 
 #contentBoxIn {
-	padding-top: 10px;
+	padding-top: 3px;
 }
 
 .icon {
@@ -122,7 +122,7 @@ h1 {
 
 #contentBoxMenu {
 	float: right;
-	padding: 15px;
+	padding: 5px;
 	padding-right: 0px;
 	padding-bottom: 0px;
 	font-size: 14px;

--- a/extension/ui/ng/partials/episodes.html
+++ b/extension/ui/ng/partials/episodes.html
@@ -1,6 +1,6 @@
 <div id="episodes" class="mainContentBox">
-	<div style="float: left; padding-top: 8px; padding-left: 0px; padding-right: 12px; padding-bottom: 0px;">
-		<img style="max-width: 64px;" height="64" max-width="64" ng-src="{{podcastImage}}"></img>
+	<div class="sectionTitleImage">
+		<img ng-src="{{podcastImage}}"></img>
 	</div>
 	<h1 class="sectionTitle episodesSectionTitle" ng-bind-html="{ message: 'all_eps_from', arguments: [podcastTitle]} | chrome_i18n"></h1>
 	<div id="episodeList" infinite-scroll="myPagingFunction()" infinite-scroll-distance="1">

--- a/extension/ui/ng/partials/episodes.html
+++ b/extension/ui/ng/partials/episodes.html
@@ -1,12 +1,8 @@
 <div id="episodes" class="mainContentBox">
-	<table>
-		<tbody>
-			<tr>
-				<td><img height="50" ng-src="{{podcastImage}}"></img></td>
-				<td><h1 class="sectionTitle episodesSectionTitle" ng-bind-html="{ message: 'all_eps_from', arguments: [podcastTitle]} | chrome_i18n"></h1></td>
-			</tr>
-		</tbody>
-	</table>
+	<div style="float: left; padding-top: 8px; padding-left: 0px; padding-right: 12px; padding-bottom: 0px;">
+		<img style="max-width: 64px;" height="64" max-width="64" ng-src="{{podcastImage}}"></img>
+	</div>
+	<h1 class="sectionTitle episodesSectionTitle" ng-bind-html="{ message: 'all_eps_from', arguments: [podcastTitle]} | chrome_i18n"></h1>
 	<div id="episodeList" infinite-scroll="myPagingFunction()" infinite-scroll-distance="1">
 		<div id="listMenu" ng-show="episodes.length">
 			<select ng-model="sorting" ng-change="sortingChanged()" style="font-family: 'FontAwesome', Tahoma, sans-serif; font-size: 14px; height: 22px;">


### PR DESCRIPTION
Fix #190, https://github.com/podStation/podStation/issues/190, where the title of podcasts overflow in the podcast episodes view.

It also adjusts the size of the podcast image to be more fitting to the height of the title of the view.