### PR TITLE
Fix #207: Episode selection

### DIFF
--- a/extension/reuse/ng/services/podcastDataService.js
+++ b/extension/reuse/ng/services/podcastDataService.js
@@ -69,8 +69,14 @@
 			if(podcastUrl && podcastUrl !== episodeId.values.podcastUrl)
 				return false;
 
-			if(episode.guid && episode.guid === episodeId.values.guid)
-				return true;
+			if(episodeId.values.guid) {
+				if(episode.guid && episode.guid === episodeId.values.guid) {
+					return true;
+				}
+				else {
+					return false;
+				}
+			}
 
 			if(episode.title && episode.title === episodeId.values.title)
 				return true;

--- a/spec/background/audioPlayerService.spec.js
+++ b/spec/background/audioPlayerService.spec.js
@@ -97,6 +97,23 @@ describe('audioPlayerService', function() {
 			expect(audioBuilderService.audio.src).toBe(FEEDS.WITH_GUID.EP2.enclosure.url);
 		});
 
+		it("should play the correct episode, even when another episode with the same title exists", function() {
+			spyOn(audioBuilderService.audio, 'play');
+
+			podcastManager.addPodcast(FEEDS.WITH_GUID.URL);
+
+			$rootScope.$apply();
+
+			var episodeId = podcastDataService.episodeId(FEEDS.WITH_GUID.EP3);
+
+			messageService.for('audioPlayer').sendMessage('play', {episodeId : episodeId});
+
+			$rootScope.$apply();
+
+			expect(audioBuilderService.audio.play).toHaveBeenCalled();
+			expect(audioBuilderService.audio.src).toBe(FEEDS.WITH_GUID.EP3.enclosure.url);
+		});
+
 		it("should play a podcast WITHOUT guid", function() {
 			spyOn(audioBuilderService.audio, 'play');
 

--- a/spec/background/feeds/feed-with-guid.json
+++ b/spec/background/feeds/feed-with-guid.json
@@ -3,9 +3,20 @@
 		"title": "Feed1",
 		"description": "Description Feed 1",
 		"link": "http://feed1.podstation.com/",
-		"pubDate": "Wed, 28 Feb 2018 00:01:01 -0300",
+		"pubDate": "Wed, 6 Mar 2018 00:01:01 -0300",
 		"image": "images/rss-alt-8x.png",
 		"episodes": [{
+			"title": "Title 3",
+			"link": "http://feed1.podstation.com/?p=4",
+			"pubDate": "Wed, 6 Mar 2018 00:01:01 -0300",
+			"parsedPubDate": "2018-03-06T03:01:01.000Z",
+			"description": "Description 4",
+			"guid": "http://feed1.podstation.com/?p=4",
+			"enclosure": {
+				"url": "http://feed1.podstation.com/4.mp3",
+				"type": "audio/mpeg"
+			}
+		},{
 			"title": "Title 3",
 			"link": "http://feed1.podstation.com/?p=3",
 			"pubDate": "Wed, 28 Feb 2018 00:01:01 -0300",

--- a/spec/background/feeds/feed-with-guid.xml
+++ b/spec/background/feeds/feed-with-guid.xml
@@ -6,6 +6,16 @@
 		<description>Description Feed 1</description> 
 		<language>pt-br</language>
 		<item>
+			<!-- Same title as previous item, to test if the correct 
+			one is selected based on guid, instead of title -->
+			<title>Title 3</title>
+			<link>http://feed1.podstation.com/?p=4</link>
+			<description>Description 4</description>
+			<enclosure url="http://feed1.podstation.com/4.mp3" type="audio/mpeg" />
+			<guid isPermaLink="true">http://feed1.podstation.com/?p=4</guid>
+			<pubDate>Wed, 6 Mar 2018 00:01:01 -0300</pubDate>
+		</item>
+		<item>
 			<title>Title 3</title>
 			<link>http://feed1.podstation.com/?p=3</link>
 			<description>Description 3</description>

--- a/spec/background/feeds/feedsConstants.js
+++ b/spec/background/feeds/feedsConstants.js
@@ -32,7 +32,7 @@ const FEEDS = {
 			enclosure: {
 				url: "http://feed1.podstation.com/3.mp3",
 			}
-		}
+		},
 	},
 	WITHOUT_GUID: {
 		URL: 'https://feed-without-guid.podstation.com',


### PR DESCRIPTION
This commit fixes issue https://github.com/podStation/podStation/issues/207

When have a guid, title will not be used as fallback for episode identifier (in memory, selector based on stored ids did not change, I think :p)