### PR TITLE
Refactoring #208: Move storageService to reuse

### DIFF
--- a/extension/background/background.html
+++ b/extension/background/background.html
@@ -3,7 +3,6 @@
 	<script type="text/javascript" src="/lib/jquery.min.js"></script>
 	<script type="text/javascript" src="/lib/angular.js"></script>
 	<script type="text/javascript" src="/lib/jsmediatags.min.js"></script>
-	<script type="text/javascript" src="/lib/podStationNGReuse.min.js"></script>
 	
 	<!-- Internal reusables (pages and background)-->
 	<script type="text/javascript" src="/reuse/ng/reuse.js"></script>
@@ -13,11 +12,11 @@
 	<script type="text/javascript" src="/reuse/ng/services/podcastDataService.js"></script>
 	<script type="text/javascript" src="/reuse/ng/services/dateService.js"></script>
 	<script type="text/javascript" src="/reuse/ng/services/podcastIndexOrgService.js"></script>
+	<script type="text/javascript" src="/reuse/ng/services/storageService.js"></script>
 	<script type="text/javascript" src="/reuse/comparison.js"></script>
 	<script type="text/javascript" src="/reuse/messageServiceDefinition.js"></script>
 	
 	<script type="text/javascript" src="entities/backgroundApp.js"></script>
-	<script type="text/javascript" src="ng/services/storageService.js"></script>
 	<script type="text/javascript" src="ng/services/podcastStorageService.js"></script>
 	<script type="text/javascript" src="ng/services/playlistStorageService.js"></script>
 	<script type="text/javascript" src="entities/episodeSelector.js"></script>

--- a/extension/podstation.html
+++ b/extension/podstation.html
@@ -21,7 +21,8 @@
 		<script type="text/javascript" src="reuse/ng/services/messageService.js"></script>
 		<script type="text/javascript" src="reuse/ng/services/podcastManagerService.js"></script>
 		<script type="text/javascript" src="reuse/ng/services/podcastIndexOrgService.js"></script>
-		<script type="text/javascript" src="ui/ng/services/storageService.js"></script>
+		<script type="text/javascript" src="reuse/ng/services/storageService.js"></script>
+		<script type="text/javascript" src="ui/ng/services/storageServiceUI.js"></script>
 		<script type="text/javascript" src="ui/ng/services/socialService.js"></script>
 		<script type="text/javascript" src="ui/ng/services/episodePlayerService.js"></script>
 		<script type="text/javascript" src="ui/ng/services/searchService.js"></script>

--- a/extension/reuse/ng/services/storageService.js
+++ b/extension/reuse/ng/services/storageService.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	angular
-		.module('podstationBackgroundApp')
+		.module('podstationInternalReuse')
 		.factory('storageService', ['$q', 'browser', storageService]);
 
 	function storageService($q, browserService) {

--- a/extension/ui/ng/controllers/episodesController.js
+++ b/extension/ui/ng/controllers/episodesController.js
@@ -1,5 +1,5 @@
-myApp.controller('lastEpisodesController', ['$scope', '$routeParams', 'episodePlayer', 'messageService', 'storageService', 'socialService', 'podcastDataService',
-	function($scope, $routeParams, episodePlayer, messageService, storageService, socialService, podcastDataService) {
+myApp.controller('lastEpisodesController', ['$scope', '$routeParams', 'episodePlayer', 'messageService', 'storageServiceUI', 'socialService', 'podcastDataService',
+	function($scope, $routeParams, episodePlayer, messageService, storageServiceUI, socialService, podcastDataService) {
 
 	$scope.listType = 'big_list';
 	$scope.episodes = [];
@@ -52,7 +52,7 @@ myApp.controller('lastEpisodesController', ['$scope', '$routeParams', 'episodePl
 	$scope.listTypeChanged = listTypeChanged;
 	$scope.ready = ready;
 
-	storageService.loadSyncUIOptions(function(uiOptions) {
+	storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 		$scope.listType = uiOptions.llt;
 		optionsLoaded = true;
 	});
@@ -72,7 +72,7 @@ myApp.controller('lastEpisodesController', ['$scope', '$routeParams', 'episodePl
 	return;
 
 	function listTypeChanged() {
-		storageService.loadSyncUIOptions(function(uiOptions) {
+		storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 			uiOptions.llt = $scope.listType;
 
 			return true;
@@ -85,8 +85,8 @@ myApp.controller('lastEpisodesController', ['$scope', '$routeParams', 'episodePl
 
 }]);
 
-myApp.controller('episodesController', ['$scope', '$routeParams', 'episodePlayer', 'messageService', 'storageService', 'podcastDataService',
-	function($scope, $routeParams, episodePlayer, messageService, storageService, podcastDataService) {
+myApp.controller('episodesController', ['$scope', '$routeParams', 'episodePlayer', 'messageService', 'storageServiceUI', 'podcastDataService',
+	function($scope, $routeParams, episodePlayer, messageService, storageServiceUI, podcastDataService) {
 
 	$scope.listType = 'big_list';
 	$scope.sorting = 'by_pubdate_descending';
@@ -146,7 +146,7 @@ myApp.controller('episodesController', ['$scope', '$routeParams', 'episodePlayer
 	$scope.sortingChanged = sortingChanged;
 	$scope.isReverseOrder = isReverseOrder;
 
-	storageService.loadSyncUIOptions(function(uiOptions) {
+	storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 		$scope.listType = uiOptions.elt;
 		$scope.sorting = uiOptions.es;
 	});
@@ -166,7 +166,7 @@ myApp.controller('episodesController', ['$scope', '$routeParams', 'episodePlayer
 	return;
 
 	function listTypeChanged() {
-		storageService.loadSyncUIOptions(function(uiOptions) {
+		storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 			uiOptions.elt = $scope.listType;
 
 			return true;
@@ -174,7 +174,7 @@ myApp.controller('episodesController', ['$scope', '$routeParams', 'episodePlayer
 	}
 
 	function sortingChanged() {
-		storageService.loadSyncUIOptions(function(uiOptions) {
+		storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 			uiOptions.es = $scope.sorting;
 
 			return true;
@@ -186,8 +186,8 @@ myApp.controller('episodesController', ['$scope', '$routeParams', 'episodePlayer
 	}
 }]);
 
-myApp.controller('episodesInProgressController', ['$scope', '$routeParams', 'episodePlayer', 'messageService', 'storageService', 'podcastDataService',
-	function($scope, $routeParams, episodePlayer, messageService, storageService, podcastDataService) {
+myApp.controller('episodesInProgressController', ['$scope', '$routeParams', 'episodePlayer', 'messageService', 'storageServiceUI', 'podcastDataService',
+	function($scope, $routeParams, episodePlayer, messageService, storageServiceUI, podcastDataService) {
 
 	$scope.listType = 'big_list';
 	$scope.orderByField = 'lastTimePlayed';
@@ -244,7 +244,7 @@ myApp.controller('episodesInProgressController', ['$scope', '$routeParams', 'epi
 	$scope.listTypeChanged = listTypeChanged;
 	$scope.ready = ready;
 
-	storageService.loadSyncUIOptions(function(uiOptions) {
+	storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 		$scope.listType = uiOptions.ilt;
 		optionsLoaded = true;
 	});
@@ -270,7 +270,7 @@ myApp.controller('episodesInProgressController', ['$scope', '$routeParams', 'epi
 	return;
 
 	function listTypeChanged() {
-		storageService.loadSyncUIOptions(function(uiOptions) {
+		storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 			uiOptions.ilt = $scope.listType;
 
 			return true;

--- a/extension/ui/ng/controllers/headerController.js
+++ b/extension/ui/ng/controllers/headerController.js
@@ -1,4 +1,4 @@
-myApp.controller('headerController', ['$scope', '$location', 'analyticsService','storageService', function($scope, $location, analyticsService, storageService) {
+myApp.controller('headerController', ['$scope', '$location', 'analyticsService','storageServiceUI', function($scope, $location, analyticsService, storageServiceUI) {
 	$scope.entry = "";
 
 	$scope.editBoxKeyPress = function(event) {
@@ -26,7 +26,7 @@ myApp.controller('headerController', ['$scope', '$location', 'analyticsService',
 
 	$scope.toggleColorScheme = function() {
 		
-		storageService.loadSyncUIOptions(function(uiOptions){
+		storageServiceUI.loadSyncUIOptions(function(uiOptions){
 			
 			if( uiOptions.cs === 'dark'){
 				if($('body').hasClass('dark-scheme')){

--- a/extension/ui/ng/controllers/podcastsController.js
+++ b/extension/ui/ng/controllers/podcastsController.js
@@ -1,4 +1,4 @@
-myApp.controller('podcastsController', ['$scope', 'messageService', 'storageService', 'socialService', function($scope, messageService, storageService, socialService) {
+myApp.controller('podcastsController', ['$scope', 'messageService', 'storageServiceUI', 'socialService', function($scope, messageService, storageServiceUI, socialService) {
 	$scope.listType = 'big_list';
 	$scope.sorting = 'by_subscription_descending';
 	$scope.podcasts = [];
@@ -110,7 +110,7 @@ myApp.controller('podcastsController', ['$scope', 'messageService', 'storageServ
 
 	$scope.updatePodcastList();
 
-	storageService.loadSyncUIOptions(function(uiOptions) {
+	storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 		$scope.listType = uiOptions.plt;
 		$scope.sorting = uiOptions.ps;
 		optionsLoaded = true;
@@ -135,7 +135,7 @@ myApp.controller('podcastsController', ['$scope', 'messageService', 'storageServ
 	return;
 
 	function listTypeChanged() {
-		storageService.loadSyncUIOptions(function(uiOptions) {
+		storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 			uiOptions.plt = $scope.listType;
 
 			return true;
@@ -143,7 +143,7 @@ myApp.controller('podcastsController', ['$scope', 'messageService', 'storageServ
 	}
 
 	function sortingChanged() {
-		storageService.loadSyncUIOptions(function(uiOptions) {
+		storageServiceUI.loadSyncUIOptions(function(uiOptions) {
 			uiOptions.ps = $scope.sorting;
 
 			return true;

--- a/extension/ui/ng/podstationApp.js
+++ b/extension/ui/ng/podstationApp.js
@@ -83,8 +83,8 @@ function updSS(){
 	});
 }
 
-angular.module('podstationApp').run(['$route', '$rootScope', 'messageService', 'analyticsService', 'storageService',
-function($route, $rootScope, messageService, analyticsService, storageService) {
+angular.module('podstationApp').run(['$route', '$rootScope', 'messageService', 'analyticsService', 'storageServiceUI',
+function($route, $rootScope, messageService, analyticsService, storageServiceUI) {
 	messageService.for('optionsManager').sendMessage('getOptions', {}, function(options) {
 		if(options.integrateWithScreenShader) {
 			updSS();	
@@ -107,7 +107,7 @@ function($route, $rootScope, messageService, analyticsService, storageService) {
 			});
 		}
 
-		storageService.loadSyncUIOptions((uiOptions) => {
+		storageServiceUI.loadSyncUIOptions((uiOptions) => {
 			if(uiOptions.cs === 'dark') {
 				$('body').addClass('dark-scheme');
 			}

--- a/extension/ui/ng/services/storageServiceUI.js
+++ b/extension/ui/ng/services/storageServiceUI.js
@@ -3,9 +3,9 @@
 
 	angular
 		.module('podstationApp')
-		.factory('storageService', [storageService]);
+		.factory('storageServiceUI', [storageServiceUI]);
 
-	function storageService() {
+	function storageServiceUI() {
 		var service = {
 			loadSyncUIOptions: loadSyncUIOptions
 		};


### PR DESCRIPTION
This refactoring moves the storageService to reuse, so that it can also be used on the ui side.

It is needed for https://github.com/podStation/podStation/issues/208, but can potentially be used in other places where currently the service is not reused for storage.