### PR TITLE
Fix #204 - Removed ajax cachebusting, added HTTP conditional requests

### DIFF
--- a/extension/background/entities/podcast.js
+++ b/extension/background/entities/podcast.js
@@ -146,9 +146,14 @@ var Podcast = function(url) {
 				return;
 			}
 
-			that.httpETag = jqXHR.getResponseHeader('ETag');
-			that.httpLastModified = jqXHR.getResponseHeader('Last-Modified');
+			if(jqXHR.getResponseHeader('ETag')) {
+				that.httpETag = jqXHR.getResponseHeader('ETag');
+			}
 
+			if(jqXHR.getResponseHeader('Last-Modified')) {
+				that.httpLastModified = jqXHR.getResponseHeader('Last-Modified');
+			}
+			
 			var feedParseResult = parsePodcastFeed(data);
 
 			if(!feedParseResult) {

--- a/extension/background/entities/podcast.js
+++ b/extension/background/entities/podcast.js
@@ -27,6 +27,11 @@ var Podcast = function(url) {
 
 		var storedPodcast = {};
 
+		// >>> http headers
+		storedPodcast.httpETag = this.httpETag;
+		storedPodcast.httpLastModified = this.httpLastModified;
+		// <<< http headers
+
 		storedPodcast.title = this.title;
 		storedPodcast.description = this.description;
 		storedPodcast.link = this.link;
@@ -59,6 +64,11 @@ var Podcast = function(url) {
 		getBrowserService().storage.local.get(podcastKey, function(storageObject) {
 			if(storageObject && storageObject[podcastKey]) {
 				var storedPodcast = storageObject[podcastKey];
+
+				// >>> http headers
+				that.httpETag = storedPodcast.httpETag;
+				that.httpLastModified = storedPodcast.httpLastModified;
+				// <<< http headers
 
 				that.title = storedPodcast.title;
 				that.description = storedPodcast.description;
@@ -106,19 +116,45 @@ var Podcast = function(url) {
 		console.log('Updating: ' + this.url);
 
 		$.ajaxSetup({
-			cache: false,
-
 			accepts: {
 				xml: 'application/rss+xml, application/xml, text/xml'
 			}
 		});
 
-		var promise = (new Promise((resolve, reject) => $.get(this.url, null, null, 'xml').then((data) => {
+		let headers = {
+			'Cache-Control': 'no-cache',
+		}
+
+		if(that.httpETag) {
+			headers['If-None-Match'] = that.httpETag;
+		}
+
+		if(that.httpLastModified) {
+			headers['If-Modified-Since'] = that.httpLastModified;
+		}
+
+		var promise = (new Promise((resolve, reject) => $.ajax({
+			url: this.url, 
+			dataType: 'xml',
+			headers: headers
+		}).then((data, textStatus, jqXHR) => {
+			if(jqXHR.status === 304) {
+				console.debug('Podcast not modified, HTTP response code 304', that.url);
+				that.status = 'loaded';
+				podcastChanged(that);
+				resolve();
+				return;
+			}
+
+			that.httpETag = jqXHR.getResponseHeader('ETag');
+			that.httpLastModified = jqXHR.getResponseHeader('Last-Modified');
+
 			var feedParseResult = parsePodcastFeed(data);
 
 			if(!feedParseResult) {
 				that.status = 'failed';
 				podcastChanged(that);
+				reject();
 				return;
 			}
 

--- a/spec/reuse/ajax.mock.js
+++ b/spec/reuse/ajax.mock.js
@@ -30,7 +30,10 @@ function ajaxGetFeedFromFile(feedFileName) {
 
 		typeof settings.success === 'function' && (request.response);
 
-		var deferred = $.Deferred().resolve(request.response);
+		let jqXHR = new XMLHttpRequest();
+		jqXHR.status = 200;
+
+		var deferred = $.Deferred().resolve(request.response, null, jqXHR);
 		return deferred.promise();
 	}
 }
@@ -45,6 +48,9 @@ function ajaxGetFeed(settings) {
 
 	typeof settings.success === 'function' && settings.success(request.response);
 
-	var deferred = $.Deferred().resolve(request.response);
+	let jqXHR = new XMLHttpRequest();
+	jqXHR.status = 200;
+
+	var deferred = $.Deferred().resolve(request.response, null, jqXHR);
 	return deferred.promise();
 }


### PR DESCRIPTION
This commit fixes https://github.com/podStation/podStation/issues/204 by removing the ajax cache: false option, which introduced the `_` query parameter with a timestamp for cachebusting.
This parameter was not accepted by podbean feeds.

I have replaced it by the header Cache-Control.

At the same time, I implemented support for HTTP conditional requests.
I was expecting this to be supported by the browser directly, but it seems that for ajax requests, it must be done in code.

Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests