### PR TITLE
Enhancement #212: Avoid jumping player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Use font-family `sans-serif` for player time, it avoids the player from "jumping" ([Issue #212](https://github.com/podStation/podStation/issues/212))
+
 ## [1.40.0] - 2021-03-30
 
 ### Added

--- a/extension/ui/ng/partials/episodePlayer.html
+++ b/extension/ui/ng/partials/episodePlayer.html
@@ -92,6 +92,10 @@ input[type=range]:focus::-webkit-slider-runnable-track {
 	background: #ccc;
 }
 
+.psPlayerTimeText {
+	font-family: sans-serif;
+}
+
 .playerButtonDisabled {
 	color: gray !important;
 	cursor: default;
@@ -144,7 +148,7 @@ input[type=range]:focus::-webkit-slider-runnable-track {
 						<a href="" ng-click="episodePlayer.tooglePlaylistVisibility()"><i class="fa fa-list" title="{{'toggle_playlist' | chrome_i18n }}"></i></a>
 						<a href="" ng-click="episodePlayer.refresh()" ng-if="!episodePlayer.loading"><i class="fa fa-refresh" title="{{'refresh_player' | chrome_i18n }}"></i></a>
 						
-						<span>
+						<span class="psPlayerTimeText">
 							<span ng-if="episodePlayer.timeMouseOver"><i>{{episodePlayer.timeMouseOver | format_seconds}}</i></span>
 							<span ng-if="!episodePlayer.timeMouseOver">{{episodePlayer.time | format_seconds}}</span>
 							<span> / {{episodePlayer.duration  | format_seconds}}</span>


### PR DESCRIPTION
Changed the font-family of the text that shows the player time (length and current position) to `sans-serif`.

According to my tests on both macOS and Windows (both on Chrome), it solved the issue of the "jumping player".

The jumping on the player is caused by the width of the current time changing as the playback progresses.

Also according to my tests, this issue was only observed on mac.

I also tested using FontAwsome fixed width icons on the player since the transition of the play icon to pause icon and vice
versa also makes the player "jump". The result was not aestetically pleasing, so I left this out and accepted the
"jumping" on this case, as it happens infrequently.

Reference: https://github.com/podStation/podStation/issues/212