### PR TITLE
v4v: Value bar in player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Lightning value 4 value: Added max fee support for LNPay. It works the same way as for LND nodes. The default is 1%, it can be changed on the options.
+- Lightning value 4 value: Added value streaming information on the player, when value via lightning is configured
 
 ## [1.41.0] - 2021-05-20
 

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -123,6 +123,16 @@
 	"player_error" : {
 		"message": "Error loading your episode, click play to retry"
 	},
+	// value 4 value
+	"value_pending" : {
+		"message": "Pending"
+	},
+	"value_paid" : {
+		"message": "Paid"
+	},
+	"value_balance" : {
+		"message": "Balance"
+	},
 	// playlist
 	"remove_from_playlist": {
 		"message": "Remove from playlist"

--- a/extension/_locales/pt_BR/messages.json
+++ b/extension/_locales/pt_BR/messages.json
@@ -122,6 +122,16 @@
 	"player_error" : {
 		"message": "Erro carregando seu episódio, clique no play para tentar novamente"
 	},
+	// value 4 value
+	"value_pending" : {
+		"message": "Pendente"
+	},
+	"value_paid" : {
+		"message": "Pago"
+	},
+	"value_balance" : {
+		"message": "Saldo"
+	},
 	// playlist
 	"remove_from_playlist": {
 		"message": "Remover da playlist"

--- a/extension/background/ng/services/lightning.js
+++ b/extension/background/ng/services/lightning.js
@@ -136,18 +136,20 @@
 
 	class TestModeClient {
 		constructor(_analyticsService) {
+			this.balanceInmSats = 10000000;
 			this._analyticsService = _analyticsService;
 		}
 
 		sendPaymentWithKeySend(nodeId, amount, customRecordKey, customRecordValue, podcastPaymentMetadata) {
 			console.info('Test mode - sendPaymentWithKeySend', nodeId, amount, customRecordKey, customRecordValue, podcastPaymentMetadata);
+			this.balanceInmSats -= amount;
 			this._analyticsService.trackEvent('lightning', 'send_payment_test_mode', null, amount);
 			return Promise.resolve(); 
 		}
 
 		getBalance() {
 			return Promise.resolve({
-				balanceInSats: 10000000
+				balanceInSats: Math.round(this.balanceInmSats/1000)
 			});
 		}
 	}

--- a/extension/background/ng/services/lightning.js
+++ b/extension/background/ng/services/lightning.js
@@ -144,6 +144,12 @@
 			this._analyticsService.trackEvent('lightning', 'send_payment_test_mode', null, amount);
 			return Promise.resolve(); 
 		}
+
+		getBalance() {
+			return Promise.resolve({
+				balanceInSats: 10000000
+			});
+		}
 	}
 
 	class LNDClient {

--- a/extension/background/ng/services/valueHandler.js
+++ b/extension/background/ng/services/valueHandler.js
@@ -191,6 +191,7 @@
 				lightningService.sendPaymentWithKeySend(valueToSettle.address, valueToSettle.value, valueToSettle.customRecordKey, valueToSettle.customRecordValue, buildPodcastPaymentMetadata(valueToSettle))
 				.then(() => {
 					cumulateAddressValuesToSettledValues([valueToSettle]);
+					sendValuePaidMessage();
 				})
 				.catch((error) => {
 					cumulateAddressValuesToUnsettledValues([valueToSettle]);
@@ -219,6 +220,10 @@
 
 		function sendValueChangedMessage() {
 			messageService.for('valueHandlerService').sendMessage('valueChanged', calculateValueSummary());
+		}
+
+		function sendValuePaidMessage() {
+			messageService.for('valueHandlerService').sendMessage('valuePaid');
 		}
 		
 		function calculateValueSummary() {

--- a/extension/background/ng/services/valueHandler.js
+++ b/extension/background/ng/services/valueHandler.js
@@ -10,6 +10,7 @@
 		const PODSTATION_LNPAY_WALLET_ID = '77616c5f574d68334d6d794e76556f414e';
 
 		const unsettledValues = [];
+		const settledValues = [];
 		var lightningOptions = {};
 		
 		/**
@@ -17,8 +18,15 @@
 		 */
 		const podcastsValueCache = {};
 
+		// Notifications from other services
 		messageService.for('audioPlayer').onMessage('segmentPlayed', (playedSegment) => handlePlayedSegment(playedSegment));
 		messageService.for('lightningService').onMessage('optionsChanged', (options) => {lightningOptions = options});
+
+		// Message API from this services
+		messageService.for('valueHandlerService').onMessage('getValueSummary', (messageContent, sendResponse) => {
+			sendResponse(calculateValueSummary());
+			return true;
+		});
 
 		lightningService.getOptions().then((options) => {lightningOptions = options});
 
@@ -45,7 +53,9 @@
 
 					const proratedValues = prorateSegmentValue(segmentValue, valueConfiguration, podcastAndEpisode.podcast.url);
 
-					cumulateAddressValues(proratedValues);
+					cumulateAddressValuesToUnsettledValues(proratedValues);
+
+					sendValueChangedMessage();
 				}
 			});
 		}
@@ -143,21 +153,29 @@
 			return proratedSegmentValues;
 		}
 
-		function cumulateAddressValues(valuePerAddresses) {
+		function cumulateAddressValuesToUnsettledValues(valuePerAddresses) {
 			console.debug('valueHandlerService - values to cumulate', JSON.stringify(valuePerAddresses, null, 2))
 
+			cumulateAddressValues(valuePerAddresses, unsettledValues);
+
+			console.debug('valueHandlerService - cumulated values', JSON.stringify(unsettledValues, null, 2));
+		}
+
+		function cumulateAddressValuesToSettledValues(valuePerAddresses) {
+			cumulateAddressValues(valuePerAddresses, settledValues);
+		}
+
+		function cumulateAddressValues(valuePerAddresses, cumulateTarget) {
 			valuePerAddresses.forEach(valuePerAddress => {
-				var unsettledValueForAddress = unsettledValues.find((unsettledValue) => isSameRecipient(unsettledValue, valuePerAddress));
+				var unsettledValueForAddress = cumulateTarget.find((unsettledValue) => isSameRecipient(unsettledValue, valuePerAddress));
 
 				if(unsettledValueForAddress) {
 					unsettledValueForAddress.value += valuePerAddress.value;
 				}
 				else {
-					unsettledValues.push(valuePerAddress);
+					cumulateTarget.push(valuePerAddress);
 				}
 			});
-
-			console.debug('valueHandlerService - cumulated values', JSON.stringify(unsettledValues, null, 2));
 		}
 
 		function getPodcastAndEpisode(episodeId) {
@@ -171,8 +189,14 @@
 
 			valuesToSettle.forEach((valueToSettle) => {
 				lightningService.sendPaymentWithKeySend(valueToSettle.address, valueToSettle.value, valueToSettle.customRecordKey, valueToSettle.customRecordValue, buildPodcastPaymentMetadata(valueToSettle))
+				.then(() => {
+					cumulateAddressValuesToSettledValues([valueToSettle]);
+				})
 				.catch((error) => {
-					cumulateAddressValues([valueToSettle]);
+					cumulateAddressValuesToUnsettledValues([valueToSettle]);
+				})
+				.then(() => {
+					sendValueChangedMessage();
 				});
 			});
 		}
@@ -192,5 +216,29 @@
 				   valuePerAddress1.customRecordKey === valuePerAddress2.customRecordKey &&
 				   valuePerAddress1.customRecordValue === valuePerAddress2.customRecordValue;
 		}
+
+		function sendValueChangedMessage() {
+			messageService.for('valueHandlerService').sendMessage('valueChanged', calculateValueSummary());
+		}
+		
+		function calculateValueSummary() {
+			return {
+				isActive: lightningService.isActive(),
+				unsettledValue: calculateTotalUnsettledValue(),
+				settledValue: calculateTotalSettledValue()
+			};
+		}
+
+		function calculateTotalUnsettledValue() {
+			return calculateTotalValue(unsettledValues);
+		}
+
+		function calculateTotalSettledValue() {
+			return calculateTotalValue(settledValues);
+		}
+
+		function calculateTotalValue(cumulatedValuesPerAddress) {
+			return cumulatedValuesPerAddress.reduce((previousValue, currentValue) => previousValue + currentValue.value, 0);
+		} 
 	}
 })();

--- a/extension/podstation.html
+++ b/extension/podstation.html
@@ -29,6 +29,7 @@
 		<script type="text/javascript" src="ui/ng/directives/episodeListDirective.js"></script>
 		<script type="text/javascript" src="ui/ng/directives/participantListDirective.js"></script>
 		<script type="text/javascript" src="ui/ng/directives/episodePlayerDirective.js"></script>
+		<script type="text/javascript" src="ui/ng/directives/valueStreamingInformation.js"></script>
 		<script type="text/javascript" src="ui/ng/controllers/welcomeController.js"></script>
 		<script type="text/javascript" src="ui/ng/controllers/playlistController.js"></script>
 		<script type="text/javascript" src="ui/ng/controllers/headerController.js"></script>

--- a/extension/ui/ng/directives/valueStreamingInformation.js
+++ b/extension/ui/ng/directives/valueStreamingInformation.js
@@ -1,0 +1,31 @@
+(function() {
+	angular.module('podstationApp').directive('psValueStreamingInformation', ['$interval', 'messageService', ValueStreamingInformationDirective]);
+
+	function ValueStreamingInformationDirective($interval, messageService) {
+		return {
+			restrict: 'E',
+			controller: ValueStreamingInformation,
+			controllerAs: 'valueStreamingInformation',
+			bindToController: true,
+			templateUrl: 'ui/ng/partials/valueStreamingInformantion.html'
+		};
+
+		function ValueStreamingInformation() {
+			var valueStreamingInformationController = this;
+
+			valueStreamingInformationController.isV4vConfigured = false;
+			valueStreamingInformationController.unsettledValue = 0
+
+			messageService.for('valueHandlerService').sendMessage('getValueSummary', null, (valueSummary) => handleValueSummary(valueSummary));
+			messageService.for('valueHandlerService').onMessage('valueChanged', (valueSummary) => handleValueSummary(valueSummary));
+
+			return valueStreamingInformationController;
+
+			function handleValueSummary(valueSummary) {
+				valueStreamingInformationController.isV4vConfigured = valueSummary.isActive;
+				valueStreamingInformationController.unsettledValue = Math.round(valueSummary.unsettledValue/1000);
+				valueStreamingInformationController.settledValue = Math.round(valueSummary.settledValue/1000);
+			}
+		}
+	}
+})();

--- a/extension/ui/ng/directives/valueStreamingInformation.js
+++ b/extension/ui/ng/directives/valueStreamingInformation.js
@@ -1,23 +1,27 @@
 (function() {
-	angular.module('podstationApp').directive('psValueStreamingInformation', ['$interval', 'messageService', ValueStreamingInformationDirective]);
+	angular.module('podstationApp').directive('psValueStreamingInformation', ['messageService', ValueStreamingInformationDirective]);
 
-	function ValueStreamingInformationDirective($interval, messageService) {
+	function ValueStreamingInformationDirective(messageService) {
 		return {
 			restrict: 'E',
-			controller: ValueStreamingInformation,
+			controller: ['$scope', ValueStreamingInformation],
 			controllerAs: 'valueStreamingInformation',
 			bindToController: true,
 			templateUrl: 'ui/ng/partials/valueStreamingInformantion.html'
 		};
 
-		function ValueStreamingInformation() {
+		function ValueStreamingInformation($scope) {
 			var valueStreamingInformationController = this;
 
 			valueStreamingInformationController.isV4vConfigured = false;
-			valueStreamingInformationController.unsettledValue = 0
+			valueStreamingInformationController.unsettledValue = 0;
+			valueStreamingInformationController.balance = 0;
 
 			messageService.for('valueHandlerService').sendMessage('getValueSummary', null, (valueSummary) => handleValueSummary(valueSummary));
 			messageService.for('valueHandlerService').onMessage('valueChanged', (valueSummary) => handleValueSummary(valueSummary));
+			messageService.for('valueHandlerService').onMessage('valuePaid', () => updateBalance());
+
+			updateBalance();
 
 			return valueStreamingInformationController;
 
@@ -25,6 +29,16 @@
 				valueStreamingInformationController.isV4vConfigured = valueSummary.isActive;
 				valueStreamingInformationController.unsettledValue = Math.round(valueSummary.unsettledValue/1000);
 				valueStreamingInformationController.settledValue = Math.round(valueSummary.settledValue/1000);
+			}
+
+			function updateBalance() {
+				messageService.for('lightningService').sendMessage('getBalance', null, (response) => {
+					if(response.result) {
+						$scope.$apply(() => {
+							valueStreamingInformationController.balance = response.result.balanceInSats;
+						});
+					}
+				});
 			}
 		}
 	}

--- a/extension/ui/ng/partials/episodePlayer.html
+++ b/extension/ui/ng/partials/episodePlayer.html
@@ -133,6 +133,7 @@ input[type=range]:focus::-webkit-slider-runnable-track {
 </style>
 <div class="audioPlayer">
 	<div ng-if="episodePlayer.isVisible()" ng-class="{miniPlayer: episodePlayer.miniPlayer}">
+		<ps-value-streaming-information></ps-value-streaming-information>
 		<table>
 			<tbody>
 				<tr>

--- a/extension/ui/ng/partials/valueStreamingInformantion.html
+++ b/extension/ui/ng/partials/valueStreamingInformantion.html
@@ -1,0 +1,13 @@
+<style>
+.valueViewer {
+	background-color: #ffb811;
+	color: black;
+	padding: 5px;
+}
+</style>
+<div class="valueViewer" ng-if="valueStreamingInformation.isV4vConfigured">
+	<!--<span><strong>Streaming value?</strong> {{"Yes!"}}</span>-->
+	<span><strong>Pending:</strong> {{valueStreamingInformation.unsettledValue}} sats,</span>
+	<span><strong>Paid:</strong> {{valueStreamingInformation.settledValue}} sats,</span>
+	<!--<span><strong>Your balance:</strong> 3000 sats</span>-->
+</div>

--- a/extension/ui/ng/partials/valueStreamingInformantion.html
+++ b/extension/ui/ng/partials/valueStreamingInformantion.html
@@ -7,7 +7,7 @@
 </style>
 <div class="valueViewer" ng-if="valueStreamingInformation.isV4vConfigured">
 	<!--<span><strong>Streaming value?</strong> {{"Yes!"}}</span>-->
-	<span><strong>Pending:</strong> {{valueStreamingInformation.unsettledValue}} sats,</span>
-	<span><strong>Paid:</strong> {{valueStreamingInformation.settledValue}} sats,</span>
-	<span><strong>Balance:</strong> {{valueStreamingInformation.balance}} sats</span>
+	<span><strong>{{ 'value_pending' | chrome_i18n }}:</strong> {{valueStreamingInformation.unsettledValue}} sats,</span>
+	<span><strong>{{ 'value_paid' | chrome_i18n }}:</strong> {{valueStreamingInformation.settledValue}} sats,</span>
+	<span><strong>{{ 'value_balance' | chrome_i18n }}:</strong> {{valueStreamingInformation.balance}} sats</span>
 </div>

--- a/extension/ui/ng/partials/valueStreamingInformantion.html
+++ b/extension/ui/ng/partials/valueStreamingInformantion.html
@@ -9,5 +9,5 @@
 	<!--<span><strong>Streaming value?</strong> {{"Yes!"}}</span>-->
 	<span><strong>Pending:</strong> {{valueStreamingInformation.unsettledValue}} sats,</span>
 	<span><strong>Paid:</strong> {{valueStreamingInformation.settledValue}} sats,</span>
-	<!--<span><strong>Your balance:</strong> 3000 sats</span>-->
+	<span><strong>Balance:</strong> {{valueStreamingInformation.balance}} sats</span>
 </div>


### PR DESCRIPTION
Implements a bar that shows value 4 value information above the player.

**TODO:**
- [x] Show pending and paid sats
- [x] Show balance - 305e53b48ada9969571d599db08025bd670a9654
- [x] Translation - 95c675cb4ea8cf3388fb28aaa9ed3c1f5316264d

This ones will be left for a future PR:
- Add player option to show / hide the bar
- Show whether the podcast is value enabled

Follow up issue: https://github.com/podStation/podStation/issues/255#issue-901214145
