### PR TITLE
Enhancement #256 v4v Boost function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Lightning value 4 value: Added a boost button in the player, boost value is configurable in the options ([PR #260](https://github.com/podStation/podStation/pull/260))
+
 ## [1.42.0] - 2021-05-25
 
 ### Added

--- a/extension/background/ng/services/lightning.js
+++ b/extension/background/ng/services/lightning.js
@@ -42,6 +42,7 @@
 
 		return {
 			isActive: isActive,
+			canBoost: canBoost,
 			sendPaymentWithKeySend: sendPaymentWithKeySend,
 			getOptions: getOptions,
 			getBalance: getBalance
@@ -52,6 +53,10 @@
 		 */
 		function isActive() {
 			return options.type !== 'none';
+		}
+
+		function canBoost() {
+			return isActive() && options.valueBoost > 0;
 		}
 		
 		/**
@@ -80,6 +85,8 @@
 				return {
 					// Default is 50 sats per minute, value is msats/hour
 					value: 60 * 50000,
+					// Default boost = 10 mins of value
+					valueBoost: 10 * 50000,
 					maxFeePercent: 1,
 					type: 'none'
 				};

--- a/extension/podstation.css
+++ b/extension/podstation.css
@@ -355,7 +355,8 @@ body.dark-scheme::-webkit-scrollbar-thumb:hover {
 	background-color: var(--dark_border);
 }
 
-a.funditBtn {
+a.funditBtn, .funditBtn {
+	cursor: pointer;
 	background-color: #ffb811;
 	border-radius: 10px;
 	padding: 0px 6px 2px 5px;
@@ -366,7 +367,7 @@ a.funditBtn:visited {
 	color: black;
 }
 
-a.funditBtn:hover {
+.funditBtn:hover {
 	text-decoration: none;
 	background-color: #da9800;
 }

--- a/extension/reuse/ng/services/podcastDataService.js
+++ b/extension/reuse/ng/services/podcastDataService.js
@@ -94,6 +94,12 @@
 		 * @returns {Boolean}
 		 */
 		function episodeIdEqualsId(episodeId1, episodeId2) {
+			if(episodeId1 === episodeId2)
+				return true;
+
+			if(!(episodeId1 && episodeId2))
+				return false;
+
 			for(var key in episodeId1.values) {
 				if(episodeId1.values[key] !== episodeId2.values[key]){
 					return false;

--- a/extension/ui/ng/partials/episodePlayer.html
+++ b/extension/ui/ng/partials/episodePlayer.html
@@ -180,6 +180,7 @@ input[type=range]:focus::-webkit-slider-runnable-track {
 							<div id="progressIn" style="width: {{episodePlayer.timePercent}}%"></div>
 						</div>
 						<div style="padding-bottom: 4px;" ng-if="!episodePlayer.miniPlayer">
+							<span class="funditBtn" ng-if="episodePlayer.showBoostButton" ng-click="episodePlayer.boost()"><i class="fa fa-bolt"></i> Boost!</span>
 							<span class="psPlayerBtnSecondary psPlayerBtnSecondaryTwitter" title="{{'tweet_this_episode' | chrome_i18n}}" ng-click="episodePlayer.tweet()"><i class="fa fa-twitter"></i> {{'tweet' | chrome_i18n}}</span>
 							<!--<span style="color: gray;"> | </span>
 							<span class="psPlayerBtnSecondary icon_facebook" title="{{'facebook_share_this_episode' | chrome_i18n}}" ng-click="shareWithFacebook()"><i class="fa fa-share"></i> {{'facebook_share' | chrome_i18n}}</span>-->

--- a/extension/ui/ng/partials/options.html
+++ b/extension/ui/ng/partials/options.html
@@ -43,8 +43,11 @@
 			<span>Macaroon (authentication), HEX encoded:</span>
 			<input ng-model="lightningOptions.macaroon">
 			<br>
-			<span>Value (in millisats/hour):</span>
+			<span>Streaming value (in millisats/hour):</span>
 			<input ng-model="lightningOptions.value">
+			<br>
+			<span>Boost value (in millisats/hour):</span>
+			<input ng-model="lightningOptions.valueBoost">
 			<br>
 			<span>Maximum fee (in %):</span>
 			<input ng-model="lightningOptions.maxFeePercent">
@@ -58,8 +61,11 @@
 			<span>Wallet Access Key</span>
 			<input ng-model="lightningOptions.lnpaycoWalletAccessKey">
 			<br>
-			<span>Value (in millisats/hour):</span>
+			<span>Streaming value (in millisats/hour):</span>
 			<input ng-model="lightningOptions.value">
+			<br>
+			<span>Boost value (in millisats/boost):</span>
+			<input ng-model="lightningOptions.valueBoost">
 			<br>
 			<span>Maximum fee (in %):</span>
 			<input ng-model="lightningOptions.maxFeePercent">

--- a/extension/ui/ng/partials/valueStreamingInformantion.html
+++ b/extension/ui/ng/partials/valueStreamingInformantion.html
@@ -7,6 +7,7 @@
 </style>
 <div class="valueViewer" ng-if="valueStreamingInformation.isV4vConfigured">
 	<!--<span><strong>Streaming value?</strong> {{"Yes!"}}</span>-->
+	<span><i class="fa fa-bolt"></i></span>
 	<span><strong>{{ 'value_pending' | chrome_i18n }}:</strong> {{valueStreamingInformation.unsettledValue}} sats,</span>
 	<span><strong>{{ 'value_paid' | chrome_i18n }}:</strong> {{valueStreamingInformation.settledValue}} sats,</span>
 	<span><strong>{{ 'value_balance' | chrome_i18n }}:</strong> {{valueStreamingInformation.balance}} sats</span>


### PR DESCRIPTION
This commit addresses https://github.com/podStation/podStation/issues/256

We reached `0x100` issues, how cool is that?

With this commit I added a button to "boost" a certain amount of sats (configured in the option).

This is a common concept in value 4 value, and other apps are supporting it too.

![image](https://user-images.githubusercontent.com/260113/119902843-12ddac00-bf48-11eb-8882-38858142070d.png)

I feel we need more feedback to the user when the button is clicked, nevertheless it works fine, and there is an almost immediate reaction on the pending sats.