### PR TITLE
Feature #279 - v4v - Value support on item level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Value 4 Value: Added `<podcast:value>` on `<item>` level support
+
 ### Changed
 
 - Technical Feature: Updated the API endpoint used for LNPay ([PR #273](https://github.com/podStation/podStation/pull/273))
-- T
+- Regression: Added back lightning payment test mode options removed by mistake with [PR #206](https://github.com/podStation/podStation/pull/206)
 
 ## [1.45.0]
 

--- a/src/background/ng/services/valueHandler.js
+++ b/src/background/ng/services/valueHandler.js
@@ -76,7 +76,7 @@ function valueHandlerService($injector, $interval, $q, messageService, _analytic
 	function handleValueForEpisode(value, episodeId) {
 		const podcastAndEpisode = getPodcastAndEpisode(episodeId);
 
-		getLightningValueForPodcast(podcastAndEpisode.podcast).then((valueConfiguration) => {
+		getLightningValueForPodcastOrEpisode(podcastAndEpisode).then((valueConfiguration) => {
 			if(valueConfiguration) {
 				const proratedValues = prorateSegmentValue(value, valueConfiguration, podcastAndEpisode.podcast.url);
 
@@ -98,17 +98,16 @@ function valueHandlerService($injector, $interval, $q, messageService, _analytic
 
 		const podcastAndEpisode = getPodcastAndEpisode(episodeId);
 
-		return getLightningValueForPodcast(podcastAndEpisode.podcast).then((valueConfiguration) => Promise.resolve(valueConfiguration !== null));
+		return getLightningValueForPodcastOrEpisode(podcastAndEpisode).then((valueConfiguration) => Promise.resolve(valueConfiguration !== null));
 	}
 
-	/**
-	 * 
-	 * @param {EpisodeId} episodeId
-	 */
-	function getLightningValueForPodcast(podcast) {
+	function getLightningValueForPodcastOrEpisode(podcastAndEpisode) {
 		const deferred = $q.defer();
+
+		const podcast = podcastAndEpisode.podcast;
+		const episode = podcastAndEpisode.episode;
 		
-		const value = podcast.values && podcast.values.find((value) => value.type === 'lightning');
+		let value = findLightningValue(episode) || findLightningValue(podcast);
 
 		if(value) {
 			deferred.resolve(value)
@@ -136,6 +135,10 @@ function valueHandlerService($injector, $interval, $q, messageService, _analytic
 		}
 
 		return deferred.promise; 
+	}
+
+	function findLightningValue(episodeOrPodcast) {
+		return episodeOrPodcast.values && episodeOrPodcast.values.find((value) => value.type === 'lightning');
 	}
 
 	/**


### PR DESCRIPTION
The feed parser was already coded in order to parse value tags from items (episodes).

Now the value handled was also adapted to consider value coming from episodes.

This PR implements https://github.com/podStation/podStation/issues/279