### PR TITLE
Fix - boostagram issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.47.1]
+
+- Value 4 Value: Fixed boostagram timestamp - usage of float instead of int was casing issues with helipad (Reference [here](https://podcastindex.social/@dave/107660586392228861))
+
 ## [1.47.0]
 
 ### Added 
@@ -106,7 +110,9 @@ Unfortunately, that is a necessary change to support a better development experi
 
 - Player option to play next or previous episodes in reverse order (i.e. play older episodes next instead of newer)
 
-[Unreleased]: https://github.com/podStation/podStation/compare/v1.46.2...HEAD
+[Unreleased]: https://github.com/podStation/podStation/compare/v1.47.1...HEAD
+[1.47.1]: https://github.com/podStation/podStation/compare/v1.47.0...v1.47.1
+[1.47.0]: https://github.com/podStation/podStation/compare/v1.46.3...v1.47.0
 [1.46.3]: https://github.com/podStation/podStation/compare/v1.46.2...v1.46.3
 [1.46.2]: https://github.com/podStation/podStation/compare/v1.46.1...v1.46.2
 [1.46.1]: https://github.com/podStation/podStation/compare/v1.46.0...v1.46.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "podstation_chrome_ext",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podstation_chrome_ext",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "description": "podStation Podcast Player - Browser Extension",
   "main": "podstation.js",
   "directories": {

--- a/src/background/ng/services/valueHandler.js
+++ b/src/background/ng/services/valueHandler.js
@@ -34,7 +34,7 @@ function valueHandlerService($injector, $interval, $q, messageService, _analytic
 	messageService.for('valueHandlerService').onMessage('boost', (message, sendResponse) => {
 		boost(message.episodeId, {
 			message: message.message,
-			ts: message.currentTime
+			ts: Math.floor(message.currentTime)
 		});
 	});
 


### PR DESCRIPTION
ts on the metadata for custom field 7629169 is defined as int, but we are sending a float, thus applications that rely on it being an int are failing - see the references.

References:
- https://podcastindex.social/@dave/107660586392228861
- https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md#field-7629169