### PR TITLE
Fix bug opening multiple podStation tabs

### DIFF
--- a/src/background/podstation_bg.js
+++ b/src/background/podstation_bg.js
@@ -23,7 +23,11 @@ window.openPodStation = function(hash) {
 		});
 	}
 	else {
-		window.open(APP_PATH + ( hash ? '#' + hash : ''));
+		// chrome.tabs.create is used instead of window.open because of
+		// https://bugs.chromium.org/p/chromium/issues/detail?id=1298195
+		chrome.tabs.create({
+			url: APP_PATH + ( hash ? '#' + hash : '')
+		});
 	}
 }
 


### PR DESCRIPTION
A recent regression bug in chrome caused this issue in podStation:
https://bugs.chromium.org/p/chromium/issues/detail?id=1298195

Tabs created with `window.open` are not being returned by `chrome.extension.getViews({type: 'tab'})`.

Before, clicking the podStation button (browser action) would bring existing tabs for podStation into focus, only opening a new tab if there was not tab already open.

With the bug, a new tab is created every time the button is clicked.

This PR solved this bug.

Solves: https://github.com/podStation/podStation/issues/310