### PR TITLE
Fix #330 - Miniplayer is not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Internal refactoring
 
+### Fixed
+
+- The mini player (that shows up when scrolling down, making the main player not visible) was not showing up anymore, as a side effect of updating AngularJS ([Issue #330](https://github.com/podStation/podStation/issues/330))
+
 ## [1.47.3]
 
 - Internal refactoring

--- a/src/ui/ng/directives/episodePlayerDirective.js
+++ b/src/ui/ng/directives/episodePlayerDirective.js
@@ -2,12 +2,12 @@ function episodePlayerDirective($document, $window, analyticsService, podcastMan
 
 	return {
 		restrict: 'E',
-		scope: {
-			miniPlayer: '=miniPlayer',
-		},
+		scope: {},
 		controller: ['$scope', episodePlayerController],
 		controllerAs: 'episodePlayer',
-		bindToController: true,
+		bindToController: {
+			miniPlayer: '=miniPlayer',
+		},
 		templateUrl: 'ui/ng/partials/episodePlayer.html'
 	};
 
@@ -21,6 +21,7 @@ function episodePlayerDirective($document, $window, analyticsService, podcastMan
 		 */
 		var episodeId;
 
+		controller.$onInit = $onInit;
 		controller.forward = forward;
 		controller.backward = backward;
 		controller.nextPlaybackRateUp = nextPlaybackRateUp;
@@ -86,25 +87,27 @@ function episodePlayerDirective($document, $window, analyticsService, podcastMan
 				e.target.localName !== 'textarea';
 		}
 
-		if(controller.miniPlayer) {
-			$window.addEventListener('scroll', function() {
-				const mainPlayerBottom = $document[0].getElementById('audioPlayer').getBoundingClientRect().bottom;
-				controller.miniPlayerVisible = mainPlayerBottom < 0;
-
-				if((!(typeof controller.previousMiniPlayerVisible === 'undefined')) && 
-				   controller.miniPlayerVisible !== controller.previousMiniPlayerVisible) {
-					$scope.$apply(function() {});
-				}
-				
-				controller.previousMiniPlayerVisible = controller.miniPlayerVisible;
-			});
-		}
-
 		reset();
 
 		episodePlayer.getAudioInfo(getAudioInfoCallback);
 
 		return controller;
+
+		function $onInit() {
+			if(controller.miniPlayer) {
+				$window.addEventListener('scroll', function() {
+					const mainPlayerBottom = $document[0].getElementById('audioPlayer').getBoundingClientRect().bottom;
+					controller.miniPlayerVisible = mainPlayerBottom < 0;
+	
+					if((!(typeof controller.previousMiniPlayerVisible === 'undefined')) && 
+					   controller.miniPlayerVisible !== controller.previousMiniPlayerVisible) {
+						$scope.$apply(function() {});
+					}
+					
+					controller.previousMiniPlayerVisible = controller.miniPlayerVisible;
+				});
+			}
+		}
 
 		function reset() {
 			durationInSeconds = 0;


### PR DESCRIPTION
This was a side effect updating AngularJS (>1.6).

As of 1.6 the `bindToController` option on directives does not make the bound properties available immediately when calling controller constructor.

The code that requires these properties must be executed only
on, or after `$onInit`.

References:
- https://microeducate.tech/angularjs-upgrade-1-5-to-1-61-7-makes-directive-scope-bindings-undefined/
- https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$compile
- https://docs.angularjs.org/api/ng/service/$compile#-bindtocontroller-
- https://docs.angularjs.org/api/ng/service/$compile#life-cycle-hooks