### PR TITLE
fix: exported OPML inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The OPML file is generated with error when there are podcasts in a known error state (added, but the feed is invalid) - the generated OPML file contains only the text `undefined`. Fixes issue [#358](https://github.com/podStation/podStation/issues/358).
+
 ## [1.48.0]
 
 ### Added

--- a/src/background/entities/podcastManager.js
+++ b/src/background/entities/podcastManager.js
@@ -421,7 +421,7 @@ function PodcastManager() {
 
 	function getOpml() {
 		const subscriptions = instance.podcastList.reduce((previous, current) => {
-			return previous + `<outline title="${escapeXml(current.title)}" type="rss" xmlUrl="${escapeXml(current.url)}"/>\n`
+			return previous + `<outline title="${escapeXml(current.title) || ""}" type="rss" xmlUrl="${escapeXml(current.url)}"/>\n`
 		}, '');
 
 		return `<?xml version="1.0" encoding="utf-8"?>
@@ -436,7 +436,7 @@ function PodcastManager() {
 </body>
 </opml>`;
 		function escapeXml(unsafe) {
-			return unsafe.replace(/[<>&'"]/g, function (c) {
+			return unsafe && unsafe.replace(/[<>&'"]/g, function (c) {
 				switch (c) {
 					case '<': return '&lt;';
 					case '>': return '&gt;';


### PR DESCRIPTION
This commit fixes and error that causes the generated OPML file to be inconsistent (contains only the text "undefined"), when a podcast does not contain a title in its internal storage.

This was reported by a user and reproduced by having a feed that is invalid, this leaving the podcast in a known error state.

With this fix, the OPML will still contain this feeds, but it will have an empty title.

I could have not included a title at all for this podcast, but having an empty title was a simpler solution to implement.

Related issues:

- Fixes: https://github.com/podStation/podStation/issues/358